### PR TITLE
fix: implicitly marking parameter $tlsCipherSuite as nullable is deprecated, the explicit nullable type must be used instead

### DIFF
--- a/src/Model/Connection.php
+++ b/src/Model/Connection.php
@@ -111,8 +111,8 @@ final class Connection
         string $version,
         ?string $reason,
         ?array $subscriptionsList = [],
-        string $tlsCipherSuite = null,
-        string $authorizedUser = null
+        ?string $tlsCipherSuite = null,
+        ?string $authorizedUser = null
     ) {
         $this->tls_version = null;
         $this->cid = $cid;


### PR DESCRIPTION
EJTJ3\NatsMonitoring\Model\Connection::__construct(): Implicitly marking parameter $tlsCipherSuite as nullable is deprecated, the explicit nullable type must be used instead